### PR TITLE
Box score fixes

### DIFF
--- a/src/components/BaseParser.tsx
+++ b/src/components/BaseParser.tsx
@@ -108,7 +108,7 @@ export function ProcessMessage(event: Event, players: string[], queue: Baserunne
         }
 
         if (batterStats) {
-            if (hit || homer || out || strikeout || fc || doublePlay) batterStats.atBats++;
+            if (hit || homer || out || strikeout || fc || doublePlay || error) batterStats.atBats++;
             if (hit || homer) batterStats.hits++;
             if (homer) {
                 batterStats.homeRuns++;
@@ -122,7 +122,7 @@ export function ProcessMessage(event: Event, players: string[], queue: Baserunne
             if (strike || ball) pitcherStats.pitchCount++;
             if (hit || homer) pitcherStats.hits++;
             if (homer) pitcherStats.earnedRuns++;
-            if (out || strikeout || fc) pitcherStats.outsRecorded++;
+            if (out || strikeout || fc || sacFly) pitcherStats.outsRecorded++;
             if (caughtStealing) pitcherStats.outsRecorded++;
             if (doublePlay) pitcherStats.outsRecorded += 2;
             if (strikeout) pitcherStats.strikeouts++;


### PR DESCRIPTION
Errors should count as an AB for the batter. Sac flies should credit an out to the pitcher.